### PR TITLE
Adhere to XDG Base Directory Specification

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -59,69 +59,77 @@ go install ./cmd/juga
 # 1. 바이너리 삭제
 rm $(go env GOPATH)/bin/juga || sudo rm /usr/local/bin/juga
 
-# 2. 설정 파일 및 종목 데이터베이스 삭제
-rm -rf ~/.juga
+# 2. 설정 및 데이터 삭제 (XDG 표준 준수)
+rm -rf ~/.config/juga ~/.local/share/juga ~/.cache/juga
 ```
 
 **Windows:**
-GOPATH의 `bin` 폴더에서 `juga.exe`를 삭제 후, 사용자 디렉토리(`%USERPROFILE%`)에서 `.juga` 폴더 삭제.
+`juga.exe` 파일을 삭제하고 다음 폴더들을 제거하세요:
+- `%APPDATA%\juga` (설정)
+- `%LOCALAPPDATA%\juga` (데이터 및 캐시)
 
 ## 🏎️ 빠른 시작
 ```bash
-# 1. 여러 종목 확인 (종목명, 코드, 별칭을 섞어서 사용할 수 있습니다)
+# 1. 이름, 코드, 별칭을 섞어서 조회
 juga sam 005380 SK하이닉스
 
-# 2. 종목 코드가 기억나지 않을 때 검색
+# 2. 종목 코드를 모를 땐 검색
 juga find 삼전
 
 # 3. 별칭 설정
 juga alias set sam 005380
 
-# 4. 설정한 별칭으로 검색
+# 4. 설정한 별칭으로 조회
 juga sam
 
-# 5. 관심 종목들을 포트폴리오로 묶기
-juga portfolio set 내주식 sam NAVER 005380
+# 5. 포트폴리오 생성 (여러 종목 묶음)
+juga portfolio set my-tech sam NAVER 005380
 
-# 6. 포트폴리오 한 번에 확인
-juga 내주식
+# 6. 포트폴리오 한 번에 조회
+juga my-tech
 ```
 
-## 💻 명령어
-| 명령어 | 약칭 | 설명 |
+## 💻 명령어 (Commands)
+| 명령어 | 단축어 | 설명 |
 | :--- | :--- | :--- |
-| `juga [names...]` | - | **빠른 확인.** 종목명, 코드, 별칭, 포트폴리오의 실시간 가격과 변동 확인. |
-| `juga alias set <nick> <tgt>` | `a set` | 별칭 등록 (별칭 → 종목명/코드 매칭) |
-| `juga alias edit` | `a edit`, `a e` | 별칭 목록 편집 |
-| `juga alias list` | `a list`, `a ls` | 별칭 목록 표기 |
-| `juga alias remove <nick>` | `a remove`, `a rm` | 특정 별칭 삭제 |
-| `juga portfolio set <name> [s...]` | `p set` | 종목 모음(포트폴리오) 생성 / 덮어쓰기 |
-| `juga portfolio edit <name>` | `p edit`, `p e` | 포트폴리오 종목 수정 |
-| `juga portfolio list` | `p list`, `p ls` | 포트폴리오 목록 표기 |
-| `juga portfolio remove <name>` | `p remove`, `p rm` | 포트폴리오 삭제 |
-| `juga find <query>` | `f`, `search` | 종목명으로 코드 검색 |
-| `juga update` | `up` | 최신 종목 리스트 조회 및 갱신 |
-| `juga market` | `m` | 상세 시장 지수(KOSPI/KOSDAQ) 정보 확인 |
+| `juga [names...]` | - | **빠른 조회.** 종목명, 코드, 별칭, 포트폴리오의 실시간 시세를 조회합니다. |
+| `juga alias set <nick> <tgt>` | `a set` | 별칭을 등록합니다. (예: `juga a set 삼전 005930`) |
+| `juga alias edit` | `a edit`, `a e` | 모든 별칭을 텍스트 에디터에서 엽니다. |
+| `juga alias list` | `a list`, `a ls` | 저장된 모든 별칭 목록을 보여줍니다. |
+| `juga alias remove <nick>` | `a remove`, `a rm` | 별칭을 삭제합니다. |
+| `juga portfolio set <name> [s...]` | `p set` | 포트폴리오(종목 그룹)를 생성하거나 덮어씁니다. |
+| `juga portfolio edit <name>` | `p edit`, `p e` | 포트폴리오를 텍스트 에디터에서 수정합니다. |
+| `juga portfolio list` | `p list`, `p ls` | 저장된 모든 포트폴리오를 보여줍니다. |
+| `juga portfolio remove <name>` | `p remove`, `p rm` | 포트폴리오를 삭제합니다. |
+| `juga find <query>` | `f`, `search` | 마스터 종목 리스트에서 종목을 퍼지 검색합니다. |
+| `juga update` | `up` | 최신 종목 리스트를 가져와서 업데이트합니다. (네이버 금융 크롤링) |
+| `juga market` | `m` | KOSPI/KOSDAQ 지수 정보를 상세하게 보여줍니다. |
 
-## 🛠 기술 스택
+## 🛠 기술 스택 (Tech Spec)
 - **Language:** Go (Golang)
 - **CLI Framework:** `spf13/cobra`
 - **UI/Styling:** `charmbracelet/lipgloss`
 - **Fuzzy Matching:** `sahilm/fuzzy`
 - **Data Source:** 네이버 금융 실시간 폴링 API (JSON).
 
-## 📂 .dotfiles
-- **`~/.juga/aliases.json`**: 별칭과 6자리 코드를 매핑한 개인 설정 파일.
-- **`~/.juga/portfolios.json`**: 사용자 정의 포트폴리오 파일.
-- **`~/.juga/master_tickers.csv`**: 약 3,600개의 종목 정보 라이브러리. 최초 실행 시 자동 생성.
-> **참고:** Windows의 경우 `~`는 `%USERPROFILE%`을 의미합니다.
+## 📂 파일 및 설정
+`juga`는 **XDG Base Directory Specification**을 따릅니다:
 
-- **종목 해석 로직**:
-  1. 입력값이 **포트폴리오** 명칭인지 확인 (일치 시 종목 목록으로 확장)
+| 파일 | 종류 | 기본 경로 (Linux/macOS) | 환경 변수 (Override) |
+| :--- | :--- | :--- | :--- |
+| `aliases.json` | 설정 | `~/.config/juga/aliases.json` | `JUGA_CONFIG_HOME` |
+| `portfolios.json` | 설정 | `~/.config/juga/portfolios.json` | `JUGA_CONFIG_HOME` |
+| `master_tickers.csv` | 데이터 | `~/.local/share/juga/master_tickers.csv` | `JUGA_DATA_HOME` |
+| `cache.json` | 캐시 | `~/.cache/juga/cache.json` | `JUGA_CACHE_HOME` |
+
+> **참고:** Windows에서는 기본적으로 `%APPDATA%\juga` (설정) 및 `%LOCALAPPDATA%\juga` (데이터/캐시)를 사용합니다.
+
+- **종목 해결 로직**:
+  1. 입력값이 **포트폴리오**인지 확인 (있으면 종목 리스트로 확장).
   2. `aliases.json`에서 정확히 일치하는 **별칭**이 있는지 확인.
-  3. 유효한 **6자리 종목 코드**인지 확인.
-  4. `master_tickers.csv`에서 **퍼지 검색**으로 종목명 매칭.
-  5. 데이터 검색 및 수신.
+  3. 유효한 6자리 종목 코드인지 확인.
+  4. `master_tickers.csv`에서 종목명 **퍼지 검색** (Fuzzy Search).
+  5. 데이터 조회 및 출력.
 
 ## 🎨 Demo
 

--- a/README.md
+++ b/README.md
@@ -59,12 +59,14 @@ go install ./cmd/juga
 # 1. Remove the binary (check both common locations)
 rm $(go env GOPATH)/bin/juga || sudo rm /usr/local/bin/juga
 
-# 2. Remove configuration and ticker database
-rm -rf ~/.juga
+# 2. Remove configuration and data (XDG Standard)
+rm -rf ~/.config/juga ~/.local/share/juga ~/.cache/juga
 ```
 
 **Windows:**
-Delete the `juga.exe` file from your GOPATH and the `.juga` folder from your user directory (`%USERPROFILE%`).
+Delete `juga.exe` and the following directories:
+- `%APPDATA%\juga` (Config)
+- `%LOCALAPPDATA%\juga` (Data & Cache)
 
 ## 🏎️ Quick Start
 ```bash
@@ -110,11 +112,17 @@ juga my-tech
 - **Fuzzy Matching:** `sahilm/fuzzy`
 - **Data Source:** Naver Finance Real-time Polling API (JSON).
 
-## 📂 .dotfiles
-- **`~/.juga/aliases.json`**: Your private mapping of nicknames to 6-digit codes.
-- **`~/.juga/portfolios.json`**: Your private collections of stock groups.
-- **`~/.juga/master_tickers.csv`**: A library of ~3,600 stocks. Automatically initialized from embedded data.
-> **Note:** On Windows, `~` refers to `%USERPROFILE%`.
+## 📂 Files & Configuration
+`juga` follows the **XDG Base Directory Specification**:
+
+| File | Type | Default Location (Linux/macOS) | Env Override |
+| :--- | :--- | :--- | :--- |
+| `aliases.json` | Config | `~/.config/juga/aliases.json` | `JUGA_CONFIG_HOME` |
+| `portfolios.json` | Config | `~/.config/juga/portfolios.json` | `JUGA_CONFIG_HOME` |
+| `master_tickers.csv` | Data | `~/.local/share/juga/master_tickers.csv` | `JUGA_DATA_HOME` |
+| `cache.json` | Cache | `~/.cache/juga/cache.json` | `JUGA_CACHE_HOME` |
+
+> **Note:** On Windows, these default to `%APPDATA%\juga` (Config) and `%LOCALAPPDATA%\juga` (Data/Cache).
 
 - **Resolver Logic**:
   1. Check if the input is a **Portfolio** (expands to list of items).

--- a/internal/cli/clean.go
+++ b/internal/cli/clean.go
@@ -12,24 +12,37 @@ import (
 var cleanCmd = &cobra.Command{
 	Use:   "clean",
 	Short: "Clear the search cache and master ticker list",
-	Long:  `Remove the search cache (cache.json) and the local ticker database (master_tickers.csv). User-defined aliases and portfolios are preserved.`,
+	Long: `Remove the search cache (cache.json) and the local ticker database (master_tickers.csv).
+
+This cleans files from your XDG Cache and Data directories.
+User-defined aliases and portfolios in your Config directory are preserved.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		cachePath, _ := config.GetCachePath()
 		tickersPath, _ := config.GetMasterTickersPath()
 
-		filesToRemove := []string{cachePath, tickersPath}
+		filesToRemove := []struct {
+			path  string
+			label string
+		}{
+			{cachePath, "search cache"},
+			{tickersPath, "ticker database"},
+		}
+
 		removedCount := 0
 
-		for _, path := range filesToRemove {
-			if _, err := os.Stat(path); err == nil {
-				if err := os.Remove(path); err == nil {
+		for _, item := range filesToRemove {
+			if _, err := os.Stat(item.path); err == nil {
+				if err := os.Remove(item.path); err == nil {
+					fmt.Printf("Removed %s: %s\n", item.label, item.path)
 					removedCount++
+				} else {
+					fmt.Fprintf(os.Stderr, "Failed to remove %s: %v\n", item.path, err)
 				}
 			}
 		}
 
 		if removedCount > 0 {
-			fmt.Println("✨ Cache and ticker database cleaned.")
+			fmt.Println("✨ Cleanup complete.")
 		} else {
 			fmt.Println("Nothing to clean.")
 		}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -143,7 +143,7 @@ Example:
 }
 
 func Execute() {
-	if err := config.EnsureConfigDir(); err != nil {
+	if err := config.EnsureAppDirs(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error creating config directory: %v\n", err)
 		os.Exit(1)
 	}

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -4,26 +4,107 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 )
 
 const (
-	DirName               = ".juga"
 	AliasesFileName       = "aliases.json"
 	CacheFileName         = "cache.json"
 	MasterTickersFileName = "master_tickers.csv"
 	PortfoliosFileName    = "portfolios.json"
+
+	// Environment variable overrides
+	EnvConfigHome = "JUGA_CONFIG_HOME"
+	EnvDataHome   = "JUGA_DATA_HOME"
+	EnvCacheHome  = "JUGA_CACHE_HOME"
+
+	// XDG standard variables
+	XDGConfigHome = "XDG_CONFIG_HOME"
+	XDGDataHome   = "XDG_DATA_HOME"
+	XDGCacheHome  = "XDG_CACHE_HOME"
 )
 
-func GetConfigDir() (string, error) {
+// getConfigHome returns the directory for configuration files (aliases, portfolios).
+// Precedence: JUGA_CONFIG_HOME > XDG_CONFIG_HOME > Default (~/.config/juga or %APPDATA%/juga)
+func getConfigHome() (string, error) {
+	if path := os.Getenv(EnvConfigHome); path != "" {
+		return path, nil
+	}
+	if path := os.Getenv(XDGConfigHome); path != "" {
+		return filepath.Join(path, "juga"), nil
+	}
+
+	if runtime.GOOS == "windows" {
+		configDir, err := os.UserConfigDir() // returns %APPDATA%
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(configDir, "juga"), nil
+	}
+
+	// Unix-like default: ~/.config/juga
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return "", fmt.Errorf("failed to get user home directory: %w", err)
+		return "", err
 	}
-	return filepath.Join(home, DirName), nil
+	return filepath.Join(home, ".config", "juga"), nil
+}
+
+// getDataHome returns the directory for data files (master_tickers.csv).
+// Precedence: JUGA_DATA_HOME > XDG_DATA_HOME > Default (~/.local/share/juga or %LOCALAPPDATA%/juga)
+func getDataHome() (string, error) {
+	if path := os.Getenv(EnvDataHome); path != "" {
+		return path, nil
+	}
+	if path := os.Getenv(XDGDataHome); path != "" {
+		return filepath.Join(path, "juga"), nil
+	}
+
+	if runtime.GOOS == "windows" {
+		// On Windows, local data usually goes to %LOCALAPPDATA%
+		cacheDir, err := os.UserCacheDir() // returns %LOCALAPPDATA%
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(cacheDir, "juga"), nil
+	}
+
+	// Unix-like default: ~/.local/share/juga
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".local", "share", "juga"), nil
+}
+
+// getCacheHome returns the directory for cache files (cache.json).
+// Precedence: JUGA_CACHE_HOME > XDG_CACHE_HOME > Default (~/.cache/juga or %LOCALAPPDATA%/juga/cache)
+func getCacheHome() (string, error) {
+	if path := os.Getenv(EnvCacheHome); path != "" {
+		return path, nil
+	}
+	if path := os.Getenv(XDGCacheHome); path != "" {
+		return filepath.Join(path, "juga"), nil
+	}
+
+	if runtime.GOOS == "windows" {
+		cacheDir, err := os.UserCacheDir() // returns %LOCALAPPDATA%
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(cacheDir, "juga", "cache"), nil
+	}
+
+	// Unix-like default: ~/.cache/juga
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".cache", "juga"), nil
 }
 
 func GetAliasesPath() (string, error) {
-	dir, err := GetConfigDir()
+	dir, err := getConfigHome()
 	if err != nil {
 		return "", err
 	}
@@ -31,7 +112,7 @@ func GetAliasesPath() (string, error) {
 }
 
 func GetCachePath() (string, error) {
-	dir, err := GetConfigDir()
+	dir, err := getCacheHome()
 	if err != nil {
 		return "", err
 	}
@@ -39,7 +120,7 @@ func GetCachePath() (string, error) {
 }
 
 func GetPortfoliosPath() (string, error) {
-	dir, err := GetConfigDir()
+	dir, err := getConfigHome()
 	if err != nil {
 		return "", err
 	}
@@ -47,23 +128,37 @@ func GetPortfoliosPath() (string, error) {
 }
 
 func GetMasterTickersPath() (string, error) {
-	dir, err := GetConfigDir()
+	dir, err := getDataHome()
 	if err != nil {
 		return "", err
 	}
 	return filepath.Join(dir, MasterTickersFileName), nil
 }
 
-func EnsureConfigDir() error {
-	dir, err := GetConfigDir()
+func EnsureAppDirs() error {
+	configDir, err := getConfigHome()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to resolve config dir: %w", err)
+	}
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		return fmt.Errorf("failed to create config dir: %w", err)
 	}
 
-	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		if err := os.MkdirAll(dir, 0755); err != nil {
-			return fmt.Errorf("failed to create config directory: %w", err)
-		}
+	dataDir, err := getDataHome()
+	if err != nil {
+		return fmt.Errorf("failed to resolve data dir: %w", err)
 	}
+	if err := os.MkdirAll(dataDir, 0755); err != nil {
+		return fmt.Errorf("failed to create data dir: %w", err)
+	}
+
+	cacheDir, err := getCacheHome()
+	if err != nil {
+		return fmt.Errorf("failed to resolve cache dir: %w", err)
+	}
+	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+		return fmt.Errorf("failed to create cache dir: %w", err)
+	}
+
 	return nil
 }


### PR DESCRIPTION
Migrate from a single `~/.juga` directory to platform-standard locations for configuration, data, and cache files. This change improves system integration and follows modern best practices for file management across different operating systems.

### Changes
- **Unix/Linux**: Implemented support for `XDG_CONFIG_HOME`, `XDG_DATA_HOME`, and `XDG_CACHE_HOME`.
- **Windows**: Implemented support for `%APPDATA%` and `%LOCALAPPDATA%`.
- **Overrides**: Added `JUGA_*` environment variables to allow manual overrides for all directory paths.
- **Tooling**: Updated the `clean` command to correctly identify and remove files across the new directory structure.
- **Documentation**: Updated the README with revised installation instructions and detailed file path information.